### PR TITLE
fix: modify query to exclude dual/synonym references

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,7 +60,9 @@
             "args": [
                 "show-deps",
                 "--seed-table",
-                "SMP_MIX_GEN_QLTY"
+                "CNS_T_RQST_ITM_ACTVTY",
+                "--schema",
+                "CONSEP"
             ]
         },
 

--- a/data-query-tool/data_query_tool/oralib.py
+++ b/data-query-tool/data_query_tool/oralib.py
@@ -539,7 +539,8 @@ class Oracle:
                         owner=:schema AND
                         (TYPE != 'TRIGGER' OR REFERENCED_OWNER != 'SYS') AND
                         (REFERENCED_NAME!=:table_name OR
-                         REFERENCED_TYPE != 'TABLE')
+                         REFERENCED_TYPE != 'TABLE') AND  NOT
+                         ( REFERENCED_OWNER = 'PUBLIC' AND REFERENCED_NAME = 'DUAL' AND REFERENCED_TYPE = 'SYNONYM' )
                 """
                 cursor = self.connection.cursor()
                 cursor.execute(

--- a/docs/presentation/notes.md
+++ b/docs/presentation/notes.md
@@ -34,11 +34,18 @@
 ```
 uv run main.py \
 create-migrations \
---seed-table seedlot \
+--seed-table SEED_PLAN_ZONE \
 --schema THE \
---migration-name seedlot_tab \
---migration-folder ./data/migrations-demo
+--migration-name seed_plan_zone \
+--migration-folder .data//migrations-demo2
 ```
+--migration-folder /home/kjnether/fsa_proj/nr-fds-pyetl/data_prep/migrations_ora/sql
 
 
 
+THE"."SEEDLOT_PLAN_ZONE
+THE"."SEEDLOT_OWNER_QUANTITY
+
+CNS_T_TEST_REP_MC
+CNS_T_TSC_TEST_RESULT
+CNS_T_RQST_ITM_ACTVTY


### PR DESCRIPTION
trigger may use a query to dual in order to populate a value.  This does not represent a dependency that we need to recreate.  Modify the query that gets the trigger dependencies so that it doesn't include dual/synonym references